### PR TITLE
Adds issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: 🐛 Bug Report
+about: I have found a bug that needs to be fixed
+
+---
+
+## Bug Report
+
+#### Issue and Steps to Reproduce
+Provide as many details as possible the explain how you encountered the bug.
+If you can provide a step by step method for recreating the bug, it can be
+verified and fixed much more rapidly.
+
+#### Versions
+What version of our application did you encounter this in?
+
+#### Screenshots
+If possible, include screenshots or gifs of you encountering the bug.
+
+##### Expected
+What is the expected behavior of the application
+
+##### Actual
+What is actually happening
+
+### Additional Details
+Provide any additional details that might be relevant to recreating
+the bug. For example, were you logged in? What permissions did you 
+have on the system? What activity were you completing before the bug 
+occurred?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+
+---
+
+## Feature Request
+
+##### Feature description
+A clear and concise description of the feature. Be detailed. Who is the
+target for the feature. How would it improve the experience or application? 
+What problem is it solving? For example, "I would like the application to support 
+Google login so that I do not need to create and remember another password. This
+should be available for all users and speeds up account creation and product access."
+
+##### Risk and reward
+In your unbiased opinion, do you consider the risk to be high/med/low/none?
+In your unbiased opinion, do you consider the reward for implementing this feature to be
+high/med/low?
+
+##### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+Are there other products or applications that implement this feature? 
+
+##### Additional details
+Include any screen shots, specific details, or possible gotchas to watch
+out for should this feature get approved. For example, "Be careful not to 
+create two accounts for users that sign in with Google, when you find
+an account that already exists with that given email"""

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,14 @@
+---
+name: ❓ Support Request
+about: Not a bug and not a feature, but you still need something
+
+---
+
+## Support Request
+
+##### Please describe how we can help
+For example, you might be experiencing issues getting your application
+to run and need more guidance. This could be because we need better 
+documentation, or perhaps you are using an unsupported operating system.
+The only way to find out is let us know what you need. Lay it out here
+and don't leave out any details 😊...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
Fixes #55 by adding issue and pull request templates. There are 3 issue templates. One for bugs, one for feature requests, and one for support requests. There is only one pull request template. 

I would like to attribute this repository for giving me some of the ideas (and for the pull request template in full). https://github.com/stevemao/github-issue-templates/